### PR TITLE
fixed IO error and docstring

### DIFF
--- a/python/pythonrc
+++ b/python/pythonrc
@@ -3,7 +3,7 @@
 
 This script adds the following things:
 
-- Readline bindings, tab completion, and history (in ~/.pyhistory,
+- Readline bindings, tab completion, and history (in ~/.history/python,
   which can be disabled by setting NOHIST in the environment)
 
 - Pretty printing of expression output (with Pygments highlighting)
@@ -65,13 +65,18 @@ def _pythonrc_enable_history():
 
         def write_history():
             if not has_written[0]:
+                readline.add_history("# start")	
                 readline.write_history_file(history_path)
                 print('Written history to %s' % history_path)
                 has_written[0] = True
         atexit.register(write_history)
 
         if os.path.isfile(history_path):
-            readline.read_history_file(history_path)
+            try:
+                readline.read_history_file(history_path)
+            except IOError:
+                pass
+		
         readline.set_history_length(-1)
 
 

--- a/python/pythonrc
+++ b/python/pythonrc
@@ -65,7 +65,6 @@ def _pythonrc_enable_history():
 
         def write_history():
             if not has_written[0]:
-                readline.add_history("# start")	
                 readline.write_history_file(history_path)
                 print('Written history to %s' % history_path)
                 has_written[0] = True


### PR DESCRIPTION
*    Added a try catch when trying to read history file to prevent IO exception a practice found in [python-doc](https://docs.python.org/2/library/readline.html)

*    Also corrected docstring with correct location of history file.